### PR TITLE
Replace jQuery .size()

### DIFF
--- a/WazeWrapLib.js
+++ b/WazeWrapLib.js
@@ -1227,7 +1227,7 @@
             jqObj = typeof selector === 'string' ?
                 $(selector) : selector instanceof $ ? selector : null;
 
-            if (!jqObj.size()) {
+            if (!jqObj.length) {
                 window.requestAnimationFrame(function () {
                     WazeWrap.Util.waitForElement(selector, callback, context);
                 });


### PR DESCRIPTION
jQuery's [.size() function](https://api.jquery.com/size/) was removed in 3.0, and WME beta is using a newer version of jQuery. This just replaces it with `.length`, which is functionally equivalent and allows WazeWrap to load on beta.