### PR TITLE
Fix layer menu checkboxes

### DIFF
--- a/WazeWrapLib.js
+++ b/WazeWrapLib.js
@@ -27,7 +27,7 @@
 
     async function init() {
         console.log("WazeWrap initializing...");
-        WazeWrap.Version = "2023.07.17.02";
+        WazeWrap.Version = "2023.07.23.01";
         WazeWrap.isBetaEditor = /beta/.test(location.href);
 		
 	loadSettings();

--- a/WazeWrapLib.js
+++ b/WazeWrapLib.js
@@ -1919,12 +1919,16 @@
                 let newLI = $('<li class="group">');
                 newLI.html([
                     '<div class="layer-switcher-toggler-tree-category">',
-					'<i class="toggle-category w-icon-caret-down" data-group-id="GROUP_' + group.toUpperCase() + '"></i>',
-					'<wz-toggle-switch class="' + groupClass + ' hydrated" id="' + groupClass + '" ' + (groupChecked ? 'checked' : '') + '>',
-					'<label class="label-text" for="' + groupClass + '">' + checkboxText + '</label>',
-                    '</div>',
-					'</li></ul>'
-                ].join(' '));
+                      // '<wz-button color="clear-icon" size="xs">',
+                      // '<i class="toggle-category w-icon w-icon-caret-down"></i>',
+                      // '</wz-button>',
+                      '<wz-toggle-switch disabled="false" class="' + groupClass + '" id="' + groupClass + '" ' + (groupChecked ? 'checked' : '') + ' name value>',
+                      '</wz-toggle-switch>',
+                      '<label class="label-text" for="' + groupClass + '">' + checkboxText + '</label>',
+                      '</div>',
+                      '<ul class="collapsible-GROUP_' + group.toUpperCase() + '"></ul>',
+                      '</li>',
+                    ].join(' '));
 
                 groupList.append(newLI);
                 $('#' + groupClass).change(function () { sessionStorage[groupClass] = this.checked; });


### PR DESCRIPTION
Previously, only the group heading for the Map Layers were showing. None of the added checkboxes would be visible.
This fixes that and increments the version number. I wasn't able to add the collapsing functionality to the layer group (cba).