### PR TITLE
Remove the usage of deprecated Segment field (geometry)

### DIFF
--- a/WazeWrapLib.js
+++ b/WazeWrapLib.js
@@ -609,7 +609,7 @@
                         continue;
                 }
 
-                let distanceToSegment = mygeometry.distanceTo(onscreenSegments[s].geometry, { details: true });
+                let distanceToSegment = mygeometry.distanceTo(onscreenSegments[s].getOLGeometry(), { details: true });
 
                 if (distanceToSegment.distance < minDistance) {
                     minDistance = distanceToSegment.distance;
@@ -736,7 +736,7 @@
                     continue;
 
                 seg = W.model.segments.getObjectById(s);
-                if (mapExtent.intersectsBounds(seg.geometry.getBounds()))
+                if (mapExtent.intersectsBounds(seg.getOLGeometry().getBounds()))
                     onScreenSegments.push(seg);
             }
             return onScreenSegments;
@@ -876,16 +876,16 @@
                 getSegmentCenterLonLat: function (segment) {
                     var x, y, componentsLength, midPoint;
                     if (segment) {
-                        componentsLength = segment.geometry.components.length;
+                        componentsLength = segment.getOLGeometry().components.length;
                         midPoint = Math.floor(componentsLength / 2);
                         if (componentsLength % 2 === 1) {
-                            x = segment.geometry.components[midPoint].x;
-                            y = segment.geometry.components[midPoint].y;
+                            x = segment.getOLGeometry().components[midPoint].x;
+                            y = segment.getOLGeometry().components[midPoint].y;
                         } else {
-                            x = (segment.geometry.components[midPoint - 1].x +
-                                segment.geometry.components[midPoint].x) / 2;
-                            y = (segment.geometry.components[midPoint - 1].y +
-                                segment.geometry.components[midPoint].y) / 2;
+                            x = (segment.getOLGeometry().components[midPoint - 1].x +
+                                segment.getOLGeometry().components[midPoint].x) / 2;
+                            y = (segment.getOLGeometry().components[midPoint - 1].y +
+                                segment.getOLGeometry().components[midPoint].y) / 2;
                         }
                         return new OpenLayers.Geometry.Point(x, y).
                             transform(W.map.getProjectionObject(), 'EPSG:4326');
@@ -1590,7 +1590,7 @@
             try {
                 response = await $.get(`${apiURL + segmentID}`);
                 if (response && response.editAreas.objects.length > 0) {
-                    let segGeoArea = response.editAreas.objects[0].geometry.coordinates[0];
+                    let segGeoArea = response.editAreas.objects[0].getOLGeometry().coordinates[0];
                     let ringGeo = [];
                     for (let i = 0; i < segGeoArea.length - 1; i++)
                         ringGeo.push(new OpenLayers.Geometry.Point(segGeoArea[i][0], segGeoArea[i][1]));

--- a/WazeWrapLib.js
+++ b/WazeWrapLib.js
@@ -27,7 +27,7 @@
 
     async function init() {
         console.log("WazeWrap initializing...");
-        WazeWrap.Version = "2024.01.23.01";
+        WazeWrap.Version = "2024.04.15.01";
         WazeWrap.isBetaEditor = /beta/.test(location.href);
 		
 	loadSettings();


### PR DESCRIPTION
The `geometry` field on the Segment data model object is deprecated and will soon be removed, according to the warning placed by WME devs. They suggest switching to the `getOLGeometry` method instead.
<img width="638" alt="image" src="https://github.com/WazeDev/WazeWrap/assets/21009377/21e2bf41-caa4-40b5-8475-227f0db8935b">

This pull request should eliminate this issue by replacing the field usage with the new method suggested.
