### PR TITLE
Switch toastr Library CDN to jsDelivr & Enforce HTTPS

### DIFF
--- a/WazeWrap.js
+++ b/WazeWrap.js
@@ -20,8 +20,7 @@ var WazeWrap = {};
     'use strict';
     const MIN_VERSION = '2019.05.01.01';
     // const WW_URL = 'https://cdn.jsdelivr.net/gh/WazeDev/WazeWrap@latest/WazeWrapLib.js'; //'https://cdn.staticaly.com/gh/WazeDev/WazeWrap/master/WazeWrapLib.js?env=dev';
-    //const WW_URL = 'https://wazedev.github.io/WazeWrap/WazeWrapLib.js';
-    const WW_URL = 'https://JS55CT.github.io/WazeWrap/WazeWrapLib.js';
+    const WW_URL = 'https://wazedev.github.io/WazeWrap/WazeWrapLib.js';
 
     async function init(){
         const sandboxed = typeof unsafeWindow !== 'undefined';

--- a/WazeWrap.js
+++ b/WazeWrap.js
@@ -20,7 +20,8 @@ var WazeWrap = {};
     'use strict';
     const MIN_VERSION = '2019.05.01.01';
     // const WW_URL = 'https://cdn.jsdelivr.net/gh/WazeDev/WazeWrap@latest/WazeWrapLib.js'; //'https://cdn.staticaly.com/gh/WazeDev/WazeWrap/master/WazeWrapLib.js?env=dev';
-    const WW_URL = 'https://wazedev.github.io/WazeWrap/WazeWrapLib.js';
+    //const WW_URL = 'https://wazedev.github.io/WazeWrap/WazeWrapLib.js';
+    const WW_URL = 'https://JS55CT.github.io/WazeWrap/WazeWrapLib.js';
 
     async function init(){
         const sandboxed = typeof unsafeWindow !== 'undefined';

--- a/WazeWrapLib.js
+++ b/WazeWrapLib.js
@@ -246,12 +246,12 @@
                 $('<link/>', {
                     rel: 'stylesheet',
                     type: 'text/css',
-                    href: 'https://cdn.statically.io/gh/WazeDev/toastr/master/build/toastr.min.css'
+                    href: 'https://cdn.jsdelivr.net/gh/WazeDev/toastr@master/build/toastr.min.css'
                 }),
                 $('<style type="text/css">.toast-container-wazedev > div {opacity: 0.95;} .toast-top-center-wide {top: 32px;}</style>')
             );
 
-            await $.getScript('https://cdn.statically.io/gh/WazeDev/toastr/master/build/toastr.min.js');
+            await $.getScript('https://cdn.jsdelivr.net/gh/WazeDev/toastr@master/build/toastr.min.js');
 		wazedevtoastr.options = {
 		    target: '#map',
 		    timeOut: 6000,


### PR DESCRIPTION
### Summary

This PR updates the method used to load the toastr JavaScript and CSS libraries in WazeWrap and related userscripts:

- **Switches from `cdn.statically.io` to `cdn.jsdelivr.net`** for all toastr dependencies.
- **Ensures all external resources are loaded over HTTPS.**
- Fixes browser **Mixed Content** issues and prevents resource loading errors in HTTPS-only environments (e.g., Waze Map Editor).

### Background

Recent changes to the `cdn.statically.io` service meant that requests for toastr assets were no longer reliably served over HTTPS, occasionally redirecting to HTTP or serving content from HTTP endpoints. Modern browsers and the Waze Map Editor block the loading of insecure (HTTP) resources within secure (HTTPS) sites due to [Content Security Policy (CSP)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) and mixed content rules.

This caused:
- toastr notifications and alerts to fail,
- `wazedevtoastr is not defined` errors,
- and a poor user experience for scripts depending on toastr via WazeWrap.

### What’s Changed

- **Updated all dynamic and static references to toastr JS and CSS to point to:**
  - `https://cdn.jsdelivr.net/gh/WazeDev/toastr@master/build/toastr.min.js`
  - `https://cdn.jsdelivr.net/gh/WazeDev/toastr@master/build/toastr.min.css`
- Validated against Content Security Policy and HTTPS restrictions in WME.

### Impact

- **No more mixed content or CSP errors:** toastr loads and initializes as expected on the Waze Map Editor.
- **No functional changes** to toastr usage—just improved reliability and compatibility.
- Existing scripts depending on WazeWrap and toastr will work seamlessly.
- Source maps for toastr may still produce benign CSP console warnings, but do not affect functionality.

### Testing

- Manually tested in current production and beta WME.
- All toastr notification types verified.
- Network tab confirms all toastr resources load via HTTPS without errors.

