### PR TITLE
Changes to move hosting of toastr to githib.io

### DIFF
--- a/WazeWrap.js
+++ b/WazeWrap.js
@@ -20,8 +20,7 @@ var WazeWrap = {};
     'use strict';
     const MIN_VERSION = '2019.05.01.01';
     // const WW_URL = 'https://cdn.jsdelivr.net/gh/WazeDev/WazeWrap@latest/WazeWrapLib.js'; //'https://cdn.staticaly.com/gh/WazeDev/WazeWrap/master/WazeWrapLib.js?env=dev';
-    //const WW_URL = 'https://wazedev.github.io/WazeWrap/WazeWrapLib.js';
-    const WW_URL = 'https://JS55CT.github.io/WazeWrap/WazeWrapLib.js';
+    const WW_URL = 'https://wazedev.github.io/WazeWrap/WazeWrapLib.js';
 
     async function init(){
         const sandboxed = typeof unsafeWindow !== 'undefined';

--- a/WazeWrap.js
+++ b/WazeWrap.js
@@ -20,7 +20,8 @@ var WazeWrap = {};
     'use strict';
     const MIN_VERSION = '2019.05.01.01';
     // const WW_URL = 'https://cdn.jsdelivr.net/gh/WazeDev/WazeWrap@latest/WazeWrapLib.js'; //'https://cdn.staticaly.com/gh/WazeDev/WazeWrap/master/WazeWrapLib.js?env=dev';
-    const WW_URL = 'https://wazedev.github.io/WazeWrap/WazeWrapLib.js';
+    //const WW_URL = 'https://wazedev.github.io/WazeWrap/WazeWrapLib.js';
+    const WW_URL = 'https://JS55CT.github.io/WazeWrap/WazeWrapLib.js';
 
     async function init(){
         const sandboxed = typeof unsafeWindow !== 'undefined';

--- a/WazeWrapLib.js
+++ b/WazeWrapLib.js
@@ -246,12 +246,12 @@
                 $('<link/>', {
                     rel: 'stylesheet',
                     type: 'text/css',
-                    href: 'https://cdn.statically.io/gh/WazeDev/toastr/master/build/toastr.min.css'
+                    href: 'https://cdn.jsdelivr.net/gh/WazeDev/toastr@master/build/toastr.min.css'
                 }),
                 $('<style type="text/css">.toast-container-wazedev > div {opacity: 0.95;} .toast-top-center-wide {top: 32px;}</style>')
             );
 
-            await $.getScript('https://cdn.statically.io/gh/WazeDev/toastr/master/build/toastr.min.js');
+            await $.getScript('https://cdn.jsdelivr.net/gh/WazeDev/toastr@master/build/toastr.min.js');
 		wazedevtoastr.options = {
 		    target: '#map',
 		    timeOut: 6000,

--- a/WazeWrapLib.js
+++ b/WazeWrapLib.js
@@ -29,6 +29,7 @@
         console.log("WazeWrap initializing...");
         WazeWrap.Version = "2025.04.11.00";
         WazeWrap.isBetaEditor = /beta/.test(location.href);
+        WazeWrap.Repo = 'JS55CT';  
 		
 	loadSettings();
 	    if(W.map.events)
@@ -44,7 +45,7 @@
         RestoreMissingSegmentFunctions();
         RestoreMissingNodeFunctions();
         RestoreMissingOLKMLSupport();
-	RestoreMissingWRule();
+        RestoreMissingWRule();
 
         WazeWrap.Geometry = new Geometry();
         WazeWrap.Model = new Model();
@@ -246,12 +247,12 @@
                 $('<link/>', {
                     rel: 'stylesheet',
                     type: 'text/css',
-                    href: 'https://cdn.jsdelivr.net/gh/WazeDev/toastr@master/build/toastr.min.css'
+                    href: 'https://'+WazeWrap.Repo+'.github.io/WazeWrap/toastr.css'
                 }),
                 $('<style type="text/css">.toast-container-wazedev > div {opacity: 0.95;} .toast-top-center-wide {top: 32px;}</style>')
             );
 
-            await $.getScript('https://cdn.jsdelivr.net/gh/WazeDev/toastr@master/build/toastr.min.js');
+            await $.getScript('https://'+WazeWrap.Repo+'.github.io/WazeWrap/toastr.js');
 		wazedevtoastr.options = {
 		    target: '#map',
 		    timeOut: 6000,

--- a/WazeWrapLib.js
+++ b/WazeWrapLib.js
@@ -29,7 +29,7 @@
         console.log("WazeWrap initializing...");
         WazeWrap.Version = "2025.04.11.00";
         WazeWrap.isBetaEditor = /beta/.test(location.href);
-        WazeWrap.Repo = 'JS55CT';  
+        WazeWrap.Repo = 'wazedev';  
 		
 	loadSettings();
 	    if(W.map.events)

--- a/toastr.css
+++ b/toastr.css
@@ -1,0 +1,269 @@
+.toast-title {
+  font-weight: 700;
+}
+.toast-message {
+  -ms-word-wrap: break-word;
+  word-wrap: break-word;
+}
+.toast-message a,
+.toast-message label {
+  color: #fff;
+}
+.toast-message a:hover {
+  color: #ccc;
+  text-decoration: none;
+}
+.toast-debug {
+  width: 700px !important;
+}
+.toast-debug > .toast-message {
+  min-height: 400px;
+  height: 60vh;
+  overflow-y: auto;
+}
+.toast-close-button {
+  position: relative;
+  right: -0.3em;
+  top: -0.3em;
+  float: right;
+  font-size: 20px;
+  font-weight: 700;
+  color: #fff;
+  -webkit-text-shadow: 0 1px 0 #fff;
+  text-shadow: 0 1px 0 #fff;
+  opacity: 0.8;
+  -ms-filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=80);
+  filter: alpha(opacity=80);
+  line-height: 1;
+}
+.toast-close-button:focus,
+.toast-close-button:hover {
+  color: #000;
+  text-decoration: none;
+  cursor: pointer;
+  opacity: 0.4;
+  -ms-filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=40);
+  filter: alpha(opacity=40);
+}
+.rtl .toast-close-button {
+  left: -0.3em;
+  float: left;
+  right: 0.3em;
+}
+button.toast-close-button {
+  padding: 0;
+  cursor: pointer;
+  background: 0 0;
+  border: 0;
+  -webkit-appearance: none;
+}
+.toast-top-center {
+  top: 0;
+  right: 0;
+  width: 100%;
+}
+.toast-bottom-center {
+  bottom: 0;
+  right: 0;
+  width: 100%;
+}
+.toast-top-full-width {
+  top: 0;
+  right: 0;
+  width: 100%;
+}
+.toast-bottom-full-width {
+  bottom: 0;
+  right: 0;
+  width: 100%;
+}
+.toast-top-center-wide {
+  top: 0;
+  right: 0;
+  width: 100%;
+}
+.toast-bottom-center-wide {
+  bottom: 0;
+  right: 0;
+  width: 100%;
+}
+.toast-top-left {
+  top: 12px;
+  left: 12px;
+}
+.toast-top-right {
+  top: 12px;
+  right: 12px;
+}
+.toast-bottom-right {
+  right: 12px;
+  bottom: 12px;
+}
+.toast-bottom-left {
+  bottom: 12px;
+  left: 12px;
+}
+.toast-container-wazedev {
+  position: absolute;
+  z-index: 999999;
+  pointer-events: none;
+}
+.toast-container-wazedev * {
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  box-sizing: border-box;
+}
+.toast-container-wazedev > div {
+  position: relative;
+  pointer-events: auto;
+  overflow: hidden;
+  margin: 0 0 6px;
+  padding: 15px 15px 15px 50px;
+  width: 300px;
+  -moz-border-radius: 3px;
+  -webkit-border-radius: 3px;
+  border-radius: 3px;
+  background-position: 15px center;
+  background-repeat: no-repeat;
+  -moz-box-shadow: 0 0 12px #999;
+  -webkit-box-shadow: 0 0 12px #999;
+  box-shadow: 0 0 12px #999;
+  color: #fff;
+  opacity: 0.8;
+  -ms-filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=80);
+  filter: alpha(opacity=80);
+}
+.toast-container-wazedev > div.rtl {
+  direction: rtl;
+  padding: 15px 50px 15px 15px;
+  background-position: right 15px center;
+}
+.toast-container-wazedev > div:hover {
+  -moz-box-shadow: 0 0 12px #000;
+  -webkit-box-shadow: 0 0 12px #000;
+  box-shadow: 0 0 12px #000;
+  opacity: 1;
+  -ms-filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=100);
+  filter: alpha(opacity=100);
+  cursor: pointer;
+}
+.toast-container-wazedev > .toast-info {
+  background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAGwSURBVEhLtZa9SgNBEMc9sUxxRcoUKSzSWIhXpFMhhYWFhaBg4yPYiWCXZxBLERsLRS3EQkEfwCKdjWJAwSKCgoKCcudv4O5YLrt7EzgXhiU3/4+b2ckmwVjJSpKkQ6wAi4gwhT+z3wRBcEz0yjSseUTrcRyfsHsXmD0AmbHOC9Ii8VImnuXBPglHpQ5wwSVM7sNnTG7Za4JwDdCjxyAiH3nyA2mtaTJufiDZ5dCaqlItILh1NHatfN5skvjx9Z38m69CgzuXmZgVrPIGE763Jx9qKsRozWYw6xOHdER+nn2KkO+Bb+UV5CBN6WC6QtBgbRVozrahAbmm6HtUsgtPC19tFdxXZYBOfkbmFJ1VaHA1VAHjd0pp70oTZzvR+EVrx2Ygfdsq6eu55BHYR8hlcki+n+kERUFG8BrA0BwjeAv2M8WLQBtcy+SD6fNsmnB3AlBLrgTtVW1c2QN4bVWLATaIS60J2Du5y1TiJgjSBvFVZgTmwCU+dAZFoPxGEEs8nyHC9Bwe2GvEJv2WXZb0vjdyFT4Cxk3e/kIqlOGoVLwwPevpYHT+00T+hWwXDf4AJAOUqWcDhbwAAAAASUVORK5CYII=) !important;
+}
+.toast-container-wazedev > .toast-error {
+  background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAHOSURBVEhLrZa/SgNBEMZzh0WKCClSCKaIYOED+AAKeQQLG8HWztLCImBrYadgIdY+gIKNYkBFSwu7CAoqCgkkoGBI/E28PdbLZmeDLgzZzcx83/zZ2SSXC1j9fr+I1Hq93g2yxH4iwM1vkoBWAdxCmpzTxfkN2RcyZNaHFIkSo10+8kgxkXIURV5HGxTmFuc75B2RfQkpxHG8aAgaAFa0tAHqYFfQ7Iwe2yhODk8+J4C7yAoRTWI3w/4klGRgR4lO7Rpn9+gvMyWp+uxFh8+H+ARlgN1nJuJuQAYvNkEnwGFck18Er4q3egEc/oO+mhLdKgRyhdNFiacC0rlOCbhNVz4H9FnAYgDBvU3QIioZlJFLJtsoHYRDfiZoUyIxqCtRpVlANq0EU4dApjrtgezPFad5S19Wgjkc0hNVnuF4HjVA6C7QrSIbylB+oZe3aHgBsqlNqKYH48jXyJKMuAbiyVJ8KzaB3eRc0pg9VwQ4niFryI68qiOi3AbjwdsfnAtk0bCjTLJKr6mrD9g8iq/S/B81hguOMlQTnVyG40wAcjnmgsCNESDrjme7wfftP4P7SP4N3CJZdvzoNyGq2c/HWOXJGsvVg+RA/k2MC/wN6I2YA2Pt8GkAAAAASUVORK5CYII=) !important;
+}
+.toast-container-wazedev > .toast-success {
+  background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAADsSURBVEhLY2AYBfQMgf///3P8+/evAIgvA/FsIF+BavYDDWMBGroaSMMBiE8VC7AZDrIFaMFnii3AZTjUgsUUWUDA8OdAH6iQbQEhw4HyGsPEcKBXBIC4ARhex4G4BsjmweU1soIFaGg/WtoFZRIZdEvIMhxkCCjXIVsATV6gFGACs4Rsw0EGgIIH3QJYJgHSARQZDrWAB+jawzgs+Q2UO49D7jnRSRGoEFRILcdmEMWGI0cm0JJ2QpYA1RDvcmzJEWhABhD/pqrL0S0CWuABKgnRki9lLseS7g2AlqwHWQSKH4oKLrILpRGhEQCw2LiRUIa4lwAAAABJRU5ErkJggg==) !important;
+}
+.toast-container-wazedev > .toast-warning {
+  background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAGYSURBVEhL5ZSvTsNQFMbXZGICMYGYmJhAQIJAICYQPAACiSDB8AiICQQJT4CqQEwgJvYASAQCiZiYmJhAIBATCARJy+9rTsldd8sKu1M0+dLb057v6/lbq/2rK0mS/TRNj9cWNAKPYIJII7gIxCcQ51cvqID+GIEX8ASG4B1bK5gIZFeQfoJdEXOfgX4QAQg7kH2A65yQ87lyxb27sggkAzAuFhbbg1K2kgCkB1bVwyIR9m2L7PRPIhDUIXgGtyKw575yz3lTNs6X4JXnjV+LKM/m3MydnTbtOKIjtz6VhCBq4vSm3ncdrD2lk0VgUXSVKjVDJXJzijW1RQdsU7F77He8u68koNZTz8Oz5yGa6J3H3lZ0xYgXBK2QymlWWA+RWnYhskLBv2vmE+hBMCtbA7KX5drWyRT/2JsqZ2IvfB9Y4bWDNMFbJRFmC9E74SoS0CqulwjkC0+5bpcV1CZ8NMej4pjy0U+doDQsGyo1hzVJttIjhQ7GnBtRFN1UarUlH8F3xict+HY07rEzoUGPlWcjRFRr4/gChZgc3ZL2d8oAAAAASUVORK5CYII=) !important;
+}
+.toast-container-wazedev > .toast-prompt {
+  background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAOwgAADsIBFShKgAAAABh0RVh0U29mdHdhcmUAcGFpbnQubmV0IDQuMS42/U4J6AAAARJJREFUSEu1k7EOhSAMRR2d3u7k/3+QfoHGqJtxcOP1NkAKViKKNzmpVLmlgJUx5lPUZEnUZERNNBfgnTbHoyYJbzpNEwVdy7IgJIvFCWfcElkahgHhVCg2zzZWBA9fpLS5ky/iCqC10oLndwXGcUSoeXvWdcUgkM0127bx2Aqtx1vZ2gPW1KRWzy3aaI7jQPgR8rzcXl96pApgMt7JFXNO/BvaN1JcoPQNkuICqS7eCIvmQy7ehb0gwX/ARezVeqV93xHYHMgCXIR43Im9rt4cSHNH9nnM84yAeYE5CAaE2gFW1nWd6fuewTMJho6TsUMOrraHbwMhv72NHMRbA+Pk6u4gBzC61XYOarIkarIcpvoDnRHBRUBBxjQAAAAASUVORK5CYII=) !important;
+}
+.toast-container-wazedev > .toast-confirm {
+  background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAYdEVYdFNvZnR3YXJlAHBhaW50Lm5ldCA0LjEuNv1OCegAAAG+SURBVEhL7ZQ9S8NQFIYbq1VRFETBbwddXYWCo+Lm7iKik/4CFydRBBGlo4u7v0Khi9hBHNTFX2CHhhZSkzb1uelJ29Q0TRpHH3i5ufec857k5iaJsNRqtZRt2yOumPdJqDcw0DAaRtvo4BsYGyoWi/fkbHA9KCXhEfMl9IZM5r4QM9BjPp9fY6pJeXdInqbw3XEJQblcNmiyKeXBkD+Ock5lNB64qTGx8YcE9QKfpSAy1F6LlT/kJEk6qac3Ye1DraNZNFetVjOVSkWiTTgHFsOo2PlDQgodW5ZlqyIMdTTPZeNY5nK5AeJ3Ku7DpKR1hqT+Uqm0xV1+mqZ5xNxzQtScphnl5kP3BgoSNTSkRllyYK4+OLVVr1x74KnUEwe/6E5QrxmGsYLBJXK2rx2Wg19yJ6hVW7LKWHCcfCD+gqakJBrc+TLFX+LlgXWlJzTDNPzX7KKK2Ntbx60NTC2O5n6hUJhgGt3cBaOruqUXfng7DElJ6x0anNYtPVyg+OYKjPZoknXFl5zVdX1XwvHBdAGlW0XTRQnHB8NztSetsHYm4fhgdiO+Df66wa//zn8DD/itY3jYprSEA0gkfgDQ/HIWcSKxGQAAAABJRU5ErkJggg==) !important;
+}
+.toast-container-wazedev > .toast-debug {
+  background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAYdEVYdFNvZnR3YXJlAHBhaW50Lm5ldCA0LjEuNv1OCegAAALKSURBVEhLnZbNa1NBFMWTaimKCq1Y0YqCuBTpRlTUhSBVkBZEbP0XrIpduNL/wL3iui5ERJBacaEQsSAEgwELIqHgokGIiUqb729/5+XmNa8vX/bAYWbuPefOvJl5Lwm0olarDcEjYr1eH4ZBS3WENOj3NX1wyFJ+lMvlSQTfqtXq90qlkqKNEpuytA/SownDn/KJilm6O1jZIJPMYP5BO6eVxuPxvaLyFJsjt0rueigU2u6YtoJcLneYIr8ptkxRB/S/wl/ZbPaQybaOYrE4Ts08T+ABE+SInzDZ1kGhl1bTB3ILJusPeHx7yfasUOhxPp+fYMXHRPqXiD2BKyZz4avBPo5R5Bbid7TrtJ8RjVtaN+ViqVR6Q+5VJpM5gP4gmufwRaFQuGIybeVxedFnaZfQ32ExY9qCPJ0C7XuC9+hH4R+EFxjPEi9oOwT686IN6+jKcBbtZeJr8Aueu7RvYRFmA8lk8iSiUVuIHnEnokVitUaZDRD6KNrQAzwLsVjMfclUkxt43oZekNwDS+Z10WkCVqpd2GH23uAQj2Lo+wmYoJJOp/eb3Q80A3CwSQ7vGq0PnSYQOPxJGrcGHHCKRyIRfRL0HUm30Lc9goqLNvRAHvM65OCXCQed1RPQlbrfJI/82nFtArluh/wBPmipc9t5gnbg3p8ynwfdJsBz1uy9QZFRWDGvi04TECvSDJu9MxDuZnsewU/0+76mxApszxK+h6ph5bxAF0SwCP/CZzDesG+g0wRoV80jb/sPIKc+JTEFpjWmHUGsm+Ci3QRooolEYpd5pmGN8zinsQt02xDqOxKm7/4O67eAeMapBDZPQH9dGpM3dyFMXHUa74HAjGcIChMWckFsBpatoDuBYuCqyVzow0dOT3HaQo03WVfThj6gv8HK1jA/pZ1nrEO9aWkPqBXUgmn/73c6lUrpA6i/NeKIhXsgEPgHYbgVlAQqkpAAAAAASUVORK5CYII=);
+}
+.toast-container-wazedev.toast-bottom-center > div,
+.toast-container-wazedev.toast-top-center > div {
+  width: 300px;
+  margin-left: auto;
+  margin-right: auto;
+}
+.toast-container-wazedev.toast-bottom-full-width > div,
+.toast-container-wazedev.toast-top-full-width > div {
+  width: 96%;
+  margin-left: auto;
+  margin-right: auto;
+}
+.toast-container-wazedev.toast-bottom-center-wide > div,
+.toast-container-wazedev.toast-top-center-wide > div {
+  width: 500px;
+  margin-left: auto;
+  margin-right: auto;
+}
+.toast-wazedev {
+  background-color: #030303;
+}
+.toast-success {
+  background-color: #51a351;
+}
+.toast-error {
+  background-color: #bd362f;
+}
+.toast-info {
+  background-color: #2f96b4;
+}
+.toast-warning {
+  background-color: #f89406;
+}
+.toast-prompt {
+  background-color: #369 !important;
+}
+.toast-confirm,
+.toast-debug {
+  background-color: #555;
+}
+.toast-progress {
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  height: 4px;
+  background-color: #000;
+  opacity: 0.4;
+  -ms-filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=40);
+  filter: alpha(opacity=40);
+}
+.toast-ok-btn {
+  margin-right: 8px;
+}
+.toast-prompt-input {
+  width: 100%;
+}
+@media all and (max-width: 240px) {
+  .toast-container-wazedev > div {
+    padding: 8px 8px 8px 50px;
+    width: 11em;
+  }
+  .toast-container-wazedev > div.rtl {
+    padding: 8px 50px 8px 8px;
+  }
+  .toast-container-wazedev .toast-close-button {
+    right: -0.2em;
+    top: -0.2em;
+  }
+  .toast-container-wazedev .rtl .toast-close-button {
+    left: -0.2em;
+    right: 0.2em;
+  }
+}
+@media all and (min-width: 241px) and (max-width: 480px) {
+  .toast-container-wazedev > div {
+    padding: 8px 8px 8px 50px;
+    width: 18em;
+  }
+  .toast-container-wazedev > div.rtl {
+    padding: 8px 50px 8px 8px;
+  }
+  .toast-container-wazedev .toast-close-button {
+    right: -0.2em;
+    top: -0.2em;
+  }
+  .toast-container-wazedev .rtl .toast-close-button {
+    left: -0.2em;
+    right: 0.2em;
+  }
+}
+@media all and (min-width: 481px) and (max-width: 768px) {
+  .toast-container-wazedev > div {
+    padding: 15px 15px 15px 50px;
+    width: 25em;
+  }
+  .toast-container-wazedev > div.rtl {
+    padding: 15px 50px 15px 15px;
+  }
+}

--- a/toastr.js
+++ b/toastr.js
@@ -1,0 +1,285 @@
+!(function (e) {
+  e(['jquery'], function (e) {
+    return (function () {
+      function t(e, t, n) {
+        return C({ type: x.error, iconClass: h().iconClasses.error, message: e, optionsOverride: n, title: t });
+      }
+      function n(t, n) {
+        return (t || (t = h()), (w = e('#' + t.containerId)), w.length ? w : (n && (w = f(t)), w));
+      }
+      function o(e, t, n) {
+        return C({ type: x.info, iconClass: h().iconClasses.info, message: e, optionsOverride: n, title: t });
+      }
+      function i(e) {
+        O = e;
+      }
+      function s(e, t, n) {
+        return C({ type: x.prompt, iconClass: h().iconClasses.prompt, message: e, optionsOverride: n, title: t });
+      }
+      function a(e, t, n) {
+        return C({ type: x.success, iconClass: h().iconClasses.success, message: e, optionsOverride: n, title: t });
+      }
+      function r(e, t, n) {
+        return C({ type: x.warning, iconClass: h().iconClasses.warning, message: e, optionsOverride: n, title: t });
+      }
+      function c(e, t) {
+        var o = h();
+        (w || n(o), m(e, o, t) || p(o));
+      }
+      function l(e, t, n) {
+        return C({ type: x.confirm, iconClass: h().iconClasses.confirm, message: e, optionsOverride: n, title: t });
+      }
+      function u(e, t, n) {
+        return (
+          console.groupCollapsed('%c' + t, 'background: #252525; color: #e94f64'),
+          console.log(e),
+          console.groupEnd(),
+          C({ type: x.debug, iconClass: h().iconClasses.debug, message: e, optionsOverride: n, title: t })
+        );
+      }
+      function d(t) {
+        var o = h();
+        return (w || n(o), t && 0 === e(':focus', t).length ? void b(t) : void (w.children().length && w.remove()));
+      }
+      function p(t) {
+        for (var n = w.children(), o = n.length - 1; o >= 0; o--) m(e(n[o]), t);
+      }
+      function m(t, n, o) {
+        var i = !(!o || !o.force) && o.force;
+        return (
+          !(!t || (!i && 0 !== e(':focus', t).length)) &&
+          (t[n.hideMethod]({
+            duration: n.hideDuration,
+            easing: n.hideEasing,
+            complete: function () {
+              b(t);
+            },
+          }),
+          !0)
+        );
+      }
+      function f(t) {
+        return ((w = e('<div/>').attr('id', t.containerId).addClass(t.positionClass).addClass(t.containerClass)), w.appendTo(e(t.target)), w);
+      }
+      function g() {
+        return {
+          tapToDismiss: !0,
+          toastClass: 'toast-wazedev',
+          containerId: 'toast-container-wazedev',
+          containerClass: 'toast-container-wazedev',
+          debug: !1,
+          showMethod: 'fadeIn',
+          showDuration: 300,
+          showEasing: 'swing',
+          onShown: void 0,
+          hideMethod: 'fadeOut',
+          hideDuration: 1e3,
+          hideEasing: 'swing',
+          onHidden: void 0,
+          closeMethod: !1,
+          closeDuration: !1,
+          closeEasing: !1,
+          closeOnHover: !0,
+          extendedTimeOut: 1e3,
+          iconClasses: { confirm: 'toast-confirm', debug: 'toast-debug', error: 'toast-error', info: 'toast-info', prompt: 'toast-prompt', success: 'toast-success', warning: 'toast-warning' },
+          iconClass: 'toast-info',
+          positionClass: 'toast-top-right',
+          timeOut: 5e3,
+          titleClass: 'toast-title',
+          messageClass: 'toast-message',
+          escapeHtml: !1,
+          target: 'body',
+          closeHtml: '<button type="button">&times;</button>',
+          closeClass: 'toast-close-button',
+          newestOnTop: !0,
+          preventDuplicates: !1,
+          progressBar: !1,
+          progressClass: 'toast-progress',
+          rtl: !1,
+          PromptDefaultInput: '',
+          ConfirmOkButtonText: 'Ok',
+          ConfirmCancelButtonText: 'Cancel',
+        };
+      }
+      function v(e) {
+        O && O(e);
+      }
+      function C(t) {
+        function o(e) {
+          return (null == e && (e = ''), e.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/'/g, '&#39;').replace(/</g, '&lt;').replace(/>/g, '&gt;'));
+        }
+        function i() {
+          (('prompt' !== t.type && 'confirm' !== t.type) || ((B.tapToDismiss = !1), (B.timeOut = 0), (B.extendedTimeOut = 0), (B.closeButton = !1)),
+            'debug' === t.type && ((B.tapToDismiss = !1), (B.timeOut = 0), (B.extendedTimeOut = 0), (B.closeButton = !0)));
+        }
+        function s() {
+          (l(), d(), p(), m(), f(), g(), C(), O(), u(), a());
+        }
+        function a() {
+          var e = '';
+          switch (t.iconClass) {
+            case 'toast-success':
+            case 'toast-info':
+              e = 'polite';
+              break;
+            default:
+              e = 'assertive';
+          }
+          q.attr('aria-live', e);
+        }
+        function r(e) {
+          (B.closeOnHover && q.hover(H, k),
+            !B.onclick && B.tapToDismiss && q.click(D),
+            B.closeButton &&
+              j &&
+              j.click(function (e) {
+                (e.stopPropagation ? e.stopPropagation() : void 0 !== e.cancelBubble && e.cancelBubble !== !0 && (e.cancelBubble = !0), B.onCloseClick && B.onCloseClick(e), D(!0));
+              }),
+            B.onclick &&
+              'prompt' !== B.type &&
+              q.click(function (e) {
+                (B.onclick(e), D());
+              }),
+            'prompt' === e.type &&
+              (S.click(function (e) {
+                (B.promptOK && B.promptOK(e, A.val()), D(!0));
+              }),
+              Q.click(function (e) {
+                (B.promptCancel && B.promptCancel(e), D(!0));
+              })),
+            'confirm' === e.type &&
+              (J.click(function (e) {
+                (B.confirmOK && B.confirmOK(e), D(!0));
+              }),
+              L.click(function (e) {
+                (B.confirmCancel && B.confirmCancel(e), D(!0));
+              })));
+        }
+        function c() {
+          (q.hide(),
+            q[B.showMethod]({ duration: B.showDuration, easing: B.showEasing, complete: B.onShown }),
+            B.timeOut > 0 &&
+              ((M = setTimeout(D, B.timeOut)), (N.maxHideTime = parseFloat(B.timeOut)), (N.hideEta = new Date().getTime() + N.maxHideTime), B.progressBar && (N.intervalId = setInterval(E, 10))));
+        }
+        function l() {
+          t.iconClass && q.addClass(B.toastClass).addClass(I);
+        }
+        function u() {
+          B.newestOnTop ? w.prepend(q) : w.append(q);
+        }
+        function d() {
+          if (t.title) {
+            var e = t.title;
+            (B.escapeHtml && (e = o(t.title)), z.append(e).addClass(B.titleClass), q.append(z));
+          }
+        }
+        function p() {
+          if (t.message) {
+            var e = t.message.replace(/\n/g, '<br/>');
+            (B.escapeHtml && (e = o(t.message)), K.append(e).addClass(B.messageClass), q.append(K));
+          }
+        }
+        function m() {
+          if ('prompt' === t.type) {
+            F.append(A);
+            var n = e('<div/>');
+            (n.append(S), n.append(Q), F.append(n), q.append(F), A.val(B.PromptDefaultInput));
+          }
+        }
+        function f() {
+          if ('confirm' === t.type) {
+            var n = e('<div/>');
+            (n.append(J), n.append(L), G.append(n), q.append(G));
+          }
+        }
+        function g() {
+          B.closeButton && (j.addClass(B.closeClass).attr('role', 'button'), q.prepend(j));
+        }
+        function C() {
+          B.progressBar && (P.addClass(B.progressClass), q.prepend(P));
+        }
+        function O() {
+          B.rtl && q.addClass('rtl');
+        }
+        function x(e, t) {
+          if (e.preventDuplicates) {
+            if (t.message === T) return !0;
+            T = t.message;
+          }
+          return !1;
+        }
+        function D(t) {
+          var n = t && B.closeMethod !== !1 ? B.closeMethod : B.hideMethod,
+            o = t && B.closeDuration !== !1 ? B.closeDuration : B.hideDuration,
+            i = t && B.closeEasing !== !1 ? B.closeEasing : B.hideEasing;
+          if (!e(':focus', q).length || t)
+            return (
+              clearTimeout(N.intervalId),
+              q[n]({
+                duration: o,
+                easing: i,
+                complete: function () {
+                  (b(q), clearTimeout(M), B.onHidden && 'hidden' !== R.state && B.onHidden(), (R.state = 'hidden'), (R.endTime = new Date()), v(R));
+                },
+              })
+            );
+        }
+        function k() {
+          (B.timeOut > 0 || B.extendedTimeOut > 0) && ((M = setTimeout(D, B.extendedTimeOut)), (N.maxHideTime = parseFloat(B.extendedTimeOut)), (N.hideEta = new Date().getTime() + N.maxHideTime));
+        }
+        function H() {
+          (clearTimeout(M), (N.hideEta = 0), q.stop(!0, !0)[B.showMethod]({ duration: B.showDuration, easing: B.showEasing }));
+        }
+        function E() {
+          var e = ((N.hideEta - new Date().getTime()) / N.maxHideTime) * 100;
+          P.width(e + '%');
+        }
+        if (0 !== t.message.length) {
+          var B = h(),
+            I = t.iconClass || B.iconClass;
+          if (('undefined' != typeof t.optionsOverride && ((B = e.extend(B, t.optionsOverride)), (I = t.optionsOverride.iconClass || I)), i(), !x(B, t))) {
+            (y++, (w = n(B, !0)));
+            var M = null,
+              q = e('<div/>'),
+              z = e('<div/>'),
+              K = e('<div/>'),
+              P = e('<div/>'),
+              j = e(B.closeHtml),
+              F = e('<div/>'),
+              S = e('<button class="btn btn-primary toast-ok-btn">Ok</button>'),
+              Q = e('<button class="btn btn-danger">Cancel</button>'),
+              A = e('<input type="text" class="toast-prompt-input"/>'),
+              G = e('<div/>'),
+              J = e('<button class="btn btn-primary toast-ok-btn"></button>');
+            J.text(B.ConfirmOkButtonText);
+            var L = e('<button class="btn btn-danger"></button>');
+            L.text(B.ConfirmCancelButtonText);
+            var N = { intervalId: null, hideEta: null, maxHideTime: null },
+              R = { toastId: y, state: 'visible', startTime: new Date(), options: B, map: t };
+            return (s(), c(), r(t), v(R), B.debug && console && console.log(R), q);
+          }
+        }
+      }
+      function h() {
+        return e.extend({}, g(), D.options);
+      }
+      function b(e) {
+        (w || (w = n()), e.is(':visible') || (e.remove(), (e = null), 0 === w.children().length && (w.remove(), (T = void 0))));
+      }
+      var w,
+        O,
+        T,
+        y = 0,
+        x = { confirm: 'confirm', error: 'error', info: 'info', prompt: 'prompt', success: 'success', warning: 'warning', debug: 'debug' },
+        D = { clear: c, confirm: l, debug: u, remove: d, error: t, getContainer: n, info: o, options: {}, prompt: s, subscribe: i, success: a, version: '2.1.5', warning: r };
+      return D;
+    })();
+  });
+})(
+  'function' == typeof define && define.amd
+    ? define
+    : function (e, t) {
+        'undefined' != typeof module && module.exports ? (module.exports = t(require('jquery'))) : (window.wazedevtoastr = t(window.jQuery));
+      },
+);
+//# sourceMappingURL=toastr.js.map


### PR DESCRIPTION
Move a copy of toastr.js and toastr.css into the repo.
Update initializeToastr() in WazeWrapLib.js to load from 'https://'+WazeWrap.Repo+'.github.io/WazeWrap/'
This will patch the WazeWrap.Alerts functionality. 